### PR TITLE
Update bert-weaviate-information-retrieval-checkpoint.ipynb

### DIFF
--- a/bert-information-retrieval/.ipynb_checkpoints/bert-weaviate-information-retrieval-checkpoint.ipynb
+++ b/bert-information-retrieval/.ipynb_checkpoints/bert-weaviate-information-retrieval-checkpoint.ipynb
@@ -9,7 +9,7 @@
     "# !pip3 install transformers\n",
     "# !pip3 install nltk\n",
     "# !pip3 install torch\n",
-    "# !pip3 install weaviate"
+    "# !pip3 install weaviate-client==3.0.0"
    ]
   },
   {


### PR DESCRIPTION
weaviate does not exist as a library, should install weaviate-client==3.0.0 instead.