### PR TITLE
Quick Demo: Add ports to weaviate service and use in newspublications

### DIFF
--- a/weaviate-transformers-newspublications/docker-compose-withgpu.yaml
+++ b/weaviate-transformers-newspublications/docker-compose-withgpu.yaml
@@ -10,6 +10,8 @@ services:
     - --scheme
     - http
     image: semitechnologies/weaviate:1.7.2
+    ports:
+    - 8080:8080
     restart: on-failure:0
     environment:
       TRANSFORMERS_INFERENCE_API: 'http://t2v-transformers:8080'
@@ -52,7 +54,7 @@ services:
   newspublications:
     image: semitechnologies/weaviate-demo-newspublications
     environment:
-    - weaviate_host=http://weaviate:4000
+    - weaviate_host=http://weaviate:8080
     depends_on:
     - weaviate
     - t2v-transformers

--- a/weaviate-transformers-newspublications/docker-compose.yaml
+++ b/weaviate-transformers-newspublications/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
     - --scheme
     - http
     image: semitechnologies/weaviate:1.7.2
+    ports:
+    - 8080:8080
     restart: on-failure:0
     environment:
       TRANSFORMERS_INFERENCE_API: 'http://t2v-transformers:8080'
@@ -38,7 +40,7 @@ services:
   newspublications:
     image: semitechnologies/weaviate-demo-newspublications
     environment:
-    - weaviate_host=http://weaviate:4000
+    - weaviate_host=http://weaviate:8080
     depends_on:
     - weaviate
     - t2v-transformers


### PR DESCRIPTION
I tried running the Quick start demo over at https://www.semi.technology/developers/weaviate/current/getting-started/quick-start.html and had trouble with the linked docker-compose file. I could not access the weaviate service through `localhost:8080` as described.
After adding the `ports` section in this PR this started to work. I'm not a Docker expert so there might be other / better ways to achieve this, but I wanted to raise this to save
other folks time.
Also, I changed to port in the `newspublications` section because before I did I didn't see any schema or objects like the quick start described. After the change I saw
lots of activity of the t2v-transformers logs and eventually also some data, so I guess this is also necessary for data to get ingested.